### PR TITLE
Depreceate Old API and add Event Listeners

### DIFF
--- a/extensions/datatools.py
+++ b/extensions/datatools.py
@@ -79,3 +79,5 @@ def import_data():
 def overwrite_data():
     clear_data()
     import_data()
+
+ext_api.add_event_listener("application_loaded", main)

--- a/extensions/debugging_tools.py
+++ b/extensions/debugging_tools.py
@@ -119,3 +119,5 @@ def exec_code_single():
 def eval_code():
     eval(simpledialog.askstring("Enter code",
                                    "Enter single line of code:"))
+
+ext_api.add_event_listener("application_loaded", main)

--- a/extensions/extensionfather.py
+++ b/extensions/extensionfather.py
@@ -28,6 +28,12 @@ def main():
     mnu.add_command(label="List All Extensions", command=list_extensions)
     mnu.add_command(label="Add Extensions", command=add_extensions)
     ext_api.register_menu(mnu)
+    
+def error_no_callback(error):
+    messagebox.showerror("Error", "There is no Autojoiner registered for "
+                                  "this meeting provider. Please install and"
+                                  " enable the extension which has the"
+                                  " required functionality.")
 
 def list_extensions():
     exts = [obj for obj in gc.get_objects() if isinstance(obj, ExtensionAPI)]
@@ -49,4 +55,5 @@ def add_extensions():
 
     messagebox.showinfo("Extension Added", "Extension Added")
 
-    
+ext_api.add_event_listener("application_loaded", main)
+ext_api.add_event_listener("no_autojoiner_callback_error", error_no_callback)

--- a/extensions/gmeet_autojoiner.py
+++ b/extensions/gmeet_autojoiner.py
@@ -168,3 +168,4 @@ def main():
     ext_api.register_autojoiner_callback(mtg_provider="GMEET",
                                      callback=autojoiner_cb)
 
+ext_api.add_event_listener("application_loaded", main)

--- a/extensions/scrollable_frame.py
+++ b/extensions/scrollable_frame.py
@@ -72,3 +72,5 @@ def main():
     data = tk.Menu(ext_api.ext_menu, tearoff = "off")
     data.add_command(label="Meeting List", command=launch_window)
     ext_api.register_menu(data)
+
+ext_api.add_event_listener("application_loaded", main)

--- a/zoom_autojoiner_gui/__init__.py
+++ b/zoom_autojoiner_gui/__init__.py
@@ -39,12 +39,22 @@ def load_window():
     window.mainloop()
 
 
+def load_extensions():
+    global exthdlr
+    exthdlr = ExtensionHandler(EXTENSIONS)
+    exthdlr.load_extensions()
+
+
 def main():
     """
     Main Function
     
     Inspired by C/C++ main() function, that looks neat
     """
+    # Extension loading
+    if EXTENSIONS.getboolean("enabled"):
+        load_extensions()
+    
     try:
         # logger.info('Attempting to initialise High DPI awareness') # Don't clutter the log
         from ctypes import windll
@@ -64,6 +74,7 @@ def main():
     except:
         pass
         # logger.critical("Failed to start child process!!!", exc_info=True)
+        
     
 if __name__ == "__main__":
     main()

--- a/zoom_autojoiner_gui/tests.py
+++ b/zoom_autojoiner_gui/tests.py
@@ -1,7 +1,7 @@
 import unittest
 
-import zoom_autojoiner_gui.views
-
+import zoom_autojoiner_gui.controllers
+import zoom_autojoiner_gui.extensions
 
 class AutojoinerClassTestCase(unittest.TestCase):
     def test_autojoiner_adding(self):
@@ -10,7 +10,75 @@ class AutojoinerClassTestCase(unittest.TestCase):
         self.assertTrue("ZUMBA" in zoom_autojoiner_gui.views.Autojoiner.autojoiner_handlers)
         self.assertEqual(zoom_autojoiner_gui.views.Autojoiner.autojoiner_handlers["ZUMBA"],
                          cb)
+class ExtensionClassTestCase(unittest.TestCase):
+    def setUp(self):
+        self.ext = zoom_autojoiner_gui.extensions.ExtensionAPI(__name__, 
+                                                               'tests')
 
+    def tearDown(self):
+        self.ext.reg_eventlisteners["test"].clear()
+        del self.ext
+        
+    def test_nonexistent_eventlistener_adding(self):
+        def cb(): pass
+        try:
+            # Nobody names an event after a person,
+            # hence it is better than putting something like
+            # 'fail' or 'testfail' or 'abc' etc.
+            self.ext.add_event_listener("kavitha", cb)
+        except Exception as e:
+            self.assertIsInstance(e, 
+                zoom_autojoiner_gui.extensions.NoSuchEventError)
+        else:
+            self.assertTrue(False) # no error - is not intended
+            
+    def test_existent_eventlistener_adding(self):
+        def cb(): pass
+        self.ext.add_event_listener("test", cb)
+        self.assertIn(cb, self.ext.reg_eventlisteners["test"])
+    
+    def test_existent_eventlistener_calling(self):
+        a = 18
+        b = 21
+        c = "Pi"
+        def cb():
+            nonlocal a
+            a = 50
+        def cb2():
+            nonlocal b
+            b = 314
+        def cb3():
+            nonlocal c
+            c = "Zeta"
+        self.ext.add_event_listener("test", cb)
+        self.ext.add_event_listener("test", cb2)
+        self.ext.add_event_listener("test", cb3)
+        self.ext.event_occured("test")
+        self.assertEqual(a, 50)
+        self.assertEqual(b, 314)
+        self.assertEqual(c, "Zeta")
+        
+    def test_existent_eventlistener_calling_only1(self):
+        a = 18
+        b = 21
+        c = "Pi"
+        def cb1():
+            nonlocal a
+            a = 50
+        def cb2():
+            nonlocal b
+            b = 314
+        def cb3():
+            nonlocal c
+            c = "Zeta"
+        self.ext.add_event_listener("test", cb1)
+        self.ext.add_event_listener("test", cb2)
+        self.ext.add_event_listener("test", cb3)
+        self.ext.event_occured("test", onlydefault=True)
+        self.assertEqual(a, 50)
+        self.assertEqual(b, 21)
+        self.assertEqual(c, "Pi")
+        
 
 
 


### PR DESCRIPTION
* The Old API, which consisted of calling functions and a permission management system, is now DEPRECATED. The functions still remain as vestigial code, which will be removed before the release of v1.0.0.
* Event Listeners have been added. This API is similar to those found in Javascript. The `add_event_listener` method of `ExtensionAPI` is used for registering event listeners.
* The "application_loaded" event replaces the `main()` function in the old API.
* Update Extensions to use "application_loaded"